### PR TITLE
Add Travis support

### DIFF
--- a/.netrc
+++ b/.netrc
@@ -1,0 +1,3 @@
+machine github.com
+  login squarescale-machine
+  password 4d8900ee28f0687ac96db2ee4b42b2ca0a5935f6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+go:
+  - tip
+before_install:
+  - cp .netrc ~
+  - chmod 600 .netrc


### PR DESCRIPTION
- ships with netrc with machine-user token (scope "repo" only) 
- adds dependencies to the makefile (so `make` works)

will add Docker auto build later when everything is merged
