### PR TITLE
[113] Make database configurable on project creation

### DIFF
--- a/squarescale/project.go
+++ b/squarescale/project.go
@@ -60,12 +60,22 @@ func (c *Client) FindProjectName() (string, error) {
 }
 
 // CreateProject asks the Squarescale platform to create a new project, using the provided name and user token.
-func (c *Client) CreateProject(name, infraType string) (taskId int, err error) {
+func (c *Client) CreateProject(name, infraType, databaseEngine, databaseClass string, enableDb bool) (taskId int, err error) {
+	dbSettings := jsonObject{
+		"enabled": enableDb,
+	}
+	if databaseEngine != "" {
+		dbSettings["engine"] = databaseEngine
+	}
+	if databaseClass != "" {
+		dbSettings["instance_class"] = databaseClass
+	}
 	payload := &jsonObject{
 		"project": jsonObject{
 			"name":       name,
 			"infra_type": getInfraTypeEnumValue(infraType),
 		},
+		"database": dbSettings,
 	}
 
 	code, body, err := c.post("/projects", payload)


### PR DESCRIPTION
https://github.com/squarescale/platform/issues/113

Example commands:

```
$ ./sqsc project create -no-db -infra-type single-node -nowait shanti-prod2
◑ create project ... done
[#15983] Created project 'shanti-prod2'

$ ./sqsc project create -db-engine toto -infra-type single-node -nowait shanti-prod2
◓ create project ... error
Cannot validate database engine 'toto'. Must be one of 'mariadb', 'MySQL', 'postgres'

$ ./sqsc project create -db-engine MySQL -db-class help -infra-type single-node -nowait shanti-prod3/squarescale-cli
◓ create project ... error
Cannot validate database class 'help'. Must be one of 'db.t2.micro', 'db.t2.small', 'db.t2.medium'

$ ./sqsc project create -db-engine MySQL -db-class db.t2.medium -infra-type single-node -nowait shanti-prod3/squarescale-cli
◑ create project ... done
[#15986] Created project 'shanti-prod3'
```