### PR TITLE
[578] Use database size instead of instance class

### DIFF
--- a/command/db-list.go
+++ b/command/db-list.go
@@ -26,7 +26,7 @@ func (c *DBListCommand) Run(args []string) int {
 		return c.errorWithUsage(fmt.Errorf("Unparsed arguments on the command line: %v", c.flagSet.Args()))
 	}
 
-	return c.runWithSpinner("list available database engines and instances", endpoint.String(), func(client *squarescale.Client) (string, error) {
+	return c.runWithSpinner("list available database engines and sizes", endpoint.String(), func(client *squarescale.Client) (string, error) {
 		engines, err := client.GetAvailableDBEngines()
 		if err != nil {
 			return "", err
@@ -34,20 +34,20 @@ func (c *DBListCommand) Run(args []string) int {
 
 		msg := fmtDBListOutput("Available engines", engines)
 
-		instances, err := client.GetAvailableDBInstances()
+		sizes, err := client.GetAvailableDBSizes()
 		if err != nil {
 			return "", err
 		}
 
 		msg += "\n\n"
-		msg += fmtDBListOutput("Available instances", instances)
+		msg += fmtDBListOutput("Available sizes", sizes.ListHuman())
 		return msg, nil
 	})
 }
 
 // Synopsis is part of cli.Command implementation.
 func (c *DBListCommand) Synopsis() string {
-	return "Lists all available database engines and instances"
+	return "Lists all available database engines and sizes"
 }
 
 // Help is part of cli.Command implementation.
@@ -55,7 +55,7 @@ func (c *DBListCommand) Help() string {
 	helpText := `
 usage: sqsc db list
 
-  Lists all database engines and instances available for use
+  Lists all database engines and sizes available for use
   in the Squarescale services.
 
 `

--- a/command/db-show.go
+++ b/command/db-show.go
@@ -33,12 +33,12 @@ func (c *DBShowCommand) Run(args []string) int {
 	}
 
 	return c.runWithSpinner("fetch database configuration", endpoint.String(), func(client *squarescale.Client) (string, error) {
-		enabled, engine, instance, e := client.GetDBConfig(*projectNameArg)
+		db, e := client.GetDBConfig(*projectNameArg)
 		if e != nil {
 			return "", e
 		}
 
-		return c.FormatTable(fmt.Sprintf("DB enabled:\t%v\nDB Engine:\t%s\nDB Instance Class:\t%s", enabled, engine, instance), false), nil
+		return c.FormatTable(fmt.Sprintf("DB enabled:\t%v\nDB Engine:\t%s\nDB Size:\t%s", db.Enabled, db.Engine, db.Size), false), nil
 	})
 }
 

--- a/command/flags.go
+++ b/command/flags.go
@@ -114,14 +114,6 @@ func clusterSizeFlag(f *flag.FlagSet) *uint {
 	return f.Uint("cluster-size", 0, "Cluster Size")
 }
 
-func dbEngineFlag(f *flag.FlagSet) *string {
-	return f.String("engine", "", "Database engine")
-}
-
-func dbEngineInstanceFlag(f *flag.FlagSet) *string {
-	return f.String("instance", "", "Database engine instance")
-}
-
 func disabledFlag(f *flag.FlagSet, doc string) *bool {
 	return f.Bool("disabled", false, doc)
 }

--- a/squarescale/db.go
+++ b/squarescale/db.go
@@ -6,24 +6,55 @@ import (
 	"net/http"
 )
 
+type DbSizes struct {
+	Sizes map[string]string `json:"sizes"`
+}
+
+func (s *DbSizes) ListHuman() []string {
+	var res []string
+	for k, v := range s.Sizes {
+		res = append(res, k+": "+v)
+	}
+	return res
+}
+
+func (s *DbSizes) CheckId(size string) bool {
+	for k, _ := range s.Sizes {
+		if k == size {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *DbSizes) ListIds() []string {
+	var res []string
+	for k, _ := range s.Sizes {
+		res = append(res, k)
+	}
+	return res
+}
+
 // GetAvailableDBInstances returns all the database instances available for use in Squarescale.
-func (c *Client) GetAvailableDBInstances() ([]string, error) {
-	code, body, err := c.get("/db/instances")
+func (c *Client) GetAvailableDBSizes() (*DbSizes, error) {
+	code, body, err := c.get("/db/sizes")
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
 	if code != http.StatusOK {
-		return []string{}, unexpectedHTTPError(code, body)
+		return nil, unexpectedHTTPError(code, body)
 	}
 
-	var instancesList []string
-	err = json.Unmarshal(body, &instancesList)
+	var sizeList DbSizes
+	sizeList.Sizes = map[string]string{}
+
+	err = json.Unmarshal(body, &sizeList)
 	if err != nil {
-		return []string{}, err
+		return nil, err
 	}
 
-	return instancesList, nil
+	return &sizeList, nil
 }
 
 // GetAvailableDBEngines returns all the database engines available for use in Squarescale.
@@ -46,43 +77,84 @@ func (c *Client) GetAvailableDBEngines() ([]string, error) {
 	return enginesList, nil
 }
 
+type DbConfig struct {
+	Enabled bool   `json:"db_enabled"`
+	Engine  string `json:"db_engine"`
+	Size    string `json:"db_size"`
+}
+
+func (db *DbConfig) String() string {
+	if db.Enabled {
+		return db.Size + " " + db.Engine
+	} else {
+		return "none"
+	}
+}
+
+func (db *DbConfig) Update(other DbConfig) {
+	db.Enabled = other.Enabled
+	if other.Size != "" {
+		db.Size = other.Size
+	}
+	if other.Engine != "" {
+		db.Engine = other.Engine
+	}
+}
+
+func (db *DbConfig) ProjectCreationSettings() jsonObject {
+	dbSettings := jsonObject{
+		"enabled": db.Enabled,
+	}
+	if db.Engine != "" {
+		dbSettings["engine"] = db.Engine
+	}
+	if db.Size != "" {
+		dbSettings["size"] = db.Size
+	}
+	return dbSettings
+}
+
+func (db *DbConfig) ConfigSettings() jsonObject {
+	dbSettings := jsonObject{
+		"db_enabled": db.Enabled,
+	}
+	if db.Engine != "" {
+		dbSettings["db_engine"] = db.Engine
+	}
+	if db.Size != "" {
+		dbSettings["db_size"] = db.Size
+	}
+	return dbSettings
+}
+
 // GetDBConfig asks the Squarescale API for the database config of a project.
 // Returns, in this order:
 // - if the db is enabled
 // - the db engine in use (string)
 // - the db instance in use (string)
-func (c *Client) GetDBConfig(project string) (bool, string, string, error) {
+func (c *Client) GetDBConfig(project string) (*DbConfig, error) {
 	code, body, err := c.get("/projects/" + project)
 	if err != nil {
-		return false, "", "", err
+		return nil, err
 	}
 
 	if code != http.StatusOK {
-		return false, "", "", unexpectedHTTPError(code, body)
+		return nil, unexpectedHTTPError(code, body)
 	}
 
-	var resp struct {
-		Enabled       bool   `json:"db_enabled"`
-		Engine        string `json:"db_engine"`
-		InstanceClass string `json:"db_instance_class"`
-	}
-
-	err = json.Unmarshal(body, &resp)
+	var db DbConfig
+	err = json.Unmarshal(body, &db)
 	if err != nil {
-		return false, "", "", err
+		return nil, err
 	}
 
-	return resp.Enabled, resp.Engine, resp.InstanceClass, nil
+	return &db, nil
 }
 
 // ConfigDB calls the Squarescale API to update database scale options for a given project.
-func (c *Client) ConfigDB(project string, enabled bool, engine, instance string) (taskId int, err error) {
+func (c *Client) ConfigDB(project string, db *DbConfig) (taskId int, err error) {
 	payload := &jsonObject{
-		"project": jsonObject{
-			"db_enabled":        enabled,
-			"db_engine":         engine,
-			"db_instance_class": instance,
-		},
+		"project": db.ConfigSettings(),
 	}
 
 	code, body, err := c.post("/projects/"+project+"/cluster", payload)
@@ -98,7 +170,7 @@ func (c *Client) ConfigDB(project string, enabled bool, engine, instance string)
 	case http.StatusNoContent:
 		return 0, nil
 	case http.StatusUnprocessableEntity:
-		return 0, fmt.Errorf("Invalid value for either database engine ('%s') or instance ('%s')", engine, instance)
+		return 0, fmt.Errorf("Invalid value for either database engine ('%s') or size ('%s')", db.Engine, db.Size)
 	default:
 		return 0, unexpectedHTTPError(code, body)
 	}

--- a/squarescale/project.go
+++ b/squarescale/project.go
@@ -66,22 +66,13 @@ func (c *Client) FindProjectName() (string, error) {
 }
 
 // CreateProject asks the Squarescale platform to create a new project, using the provided name and user token.
-func (c *Client) CreateProject(name, infraType, databaseEngine, databaseClass string, enableDb bool) (taskId int, err error) {
-	dbSettings := jsonObject{
-		"enabled": enableDb,
-	}
-	if databaseEngine != "" {
-		dbSettings["engine"] = databaseEngine
-	}
-	if databaseClass != "" {
-		dbSettings["instance_class"] = databaseClass
-	}
+func (c *Client) CreateProject(name, infraType string, db DbConfig) (taskId int, err error) {
 	payload := &jsonObject{
 		"project": jsonObject{
 			"name":       name,
 			"infra_type": getInfraTypeEnumValue(infraType),
 		},
-		"database": dbSettings,
+		"database": db.ProjectCreationSettings(),
 	}
 
 	code, body, err := c.post("/projects", payload)


### PR DESCRIPTION
Use new database sizes instead of engine class. Took the opportunity to
refactor things a bit by introducing common types DbSizes and DbConfig
that are used to different API calls. Using named fields in structs
rather than positional arguments, we ensure that such a migration is not
missed out in some part of the code.

squarescale/platform#578