### PR TITLE
Prepare for a production specific build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,15 @@ before_install:
   - chmod 600 .netrc
   - sudo pip3 install awscli
 script:
+  - make generate
+  - make lint
+after_success:
   - case "$TRAVIS_PULL_REQUEST-$TRAVIS_BRANCH" in
       false-master)
-        make publish
+        make publish-staging
         ;;
-      *)
-        make generate
+      false-production)
+        make publish
         ;;
     esac
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,12 @@ docker-darwin-amd64: ## Compile for darwin-amd64 in a container
 
 generate: docker-linux-amd64 docker-darwin-amd64
 
-publish: generate
+publish-staging: ## Publish existing generated build to github draft and s3 as staging
 	python3 publish.py
+	aws s3 cp sqsc-linux-amd64 s3://cli-releases/sqsc-linux-amd64-staging-latest --acl public-read
+	aws s3 cp sqsc-darwin-amd64 s3://cli-releases/sqsc-darwin-amd64-staging-latest --acl public-read
+
+publish: ## Publish existing generated build
 	aws s3 cp sqsc-linux-amd64 s3://cli-releases/sqsc-linux-amd64-latest --acl public-read
 	aws s3 cp sqsc-darwin-amd64 s3://cli-releases/sqsc-darwin-amd64-latest --acl public-read
 
@@ -39,5 +43,5 @@ clean: ## Clean repository
 	go clean && rm -f sqsc sqsc-*
 
 lint: ## Lint Docker
-	docker run --rm -v $$PWD:/root/ projectatomic/dockerfile-lint dockerfile_lint
-	hadolint Dockerfile
+	$(DOCKER_CMD) -v $$PWD:/root/ projectatomic/dockerfile-lint dockerfile_lint
+	$(DOCKER_CMD) -i sjourdan/hadolint < Dockerfile


### PR DESCRIPTION
- the staging version is renamed to ends with `-staging-latest`
- only staging (master) branch is published to github draft release
- travis.yml is a little bit cleaner, with script and after_success sections