### PR TITLE
[838 846] Remove update command support

### DIFF
--- a/command/container-list.go
+++ b/command/container-list.go
@@ -44,7 +44,7 @@ func (c *ContainerListCommand) Run(args []string) int {
 				continue
 			}
 			st, _ := c.Status()
-			if c.NomadStatus.PreCommand.PlacementFailure || c.NomadStatus.Service.PlacementFailure {
+			if c.NomadStatus.Service.PlacementFailure {
 				st += " (error)"
 			}
 			msg += fmt.Sprintf("%s\t%s\t%s\t%d/%d\t%v\t%d\n", c.Type, c.ShortName, st, c.Running, c.Size, c.Web, c.WebPort)

--- a/command/container-set.go
+++ b/command/container-set.go
@@ -24,8 +24,6 @@ func (c *ContainerSetCommand) Run(args []string) int {
 	containerArg := containerFlag(c.flagSet)
 	nInstancesArg := containerInstancesFlag(c.flagSet)
 	buildServiceArg := containerBuildServiceFlag(c.flagSet)
-	updateCmdArg := containerUpdateCmdFlag(c.flagSet)
-	noUpdateCmdArg := containerNoUpdateCmdFlag(c.flagSet)
 	runCmdArg := containerRunCmdFlag(c.flagSet)
 	limitMemoryArg := containerLimitMemoryFlag(c.flagSet)
 	limitCPUArg := containerLimitCPUFlag(c.flagSet)
@@ -47,10 +45,6 @@ func (c *ContainerSetCommand) Run(args []string) int {
 		return c.errorWithUsage(errors.New("Container short name cannot be empty."))
 	}
 
-	if *noUpdateCmdArg && *updateCmdArg != "" {
-		return c.errorWithUsage(errors.New("Cannot specify an update command and disable it at the same time"))
-	}
-
 	if *noRunCmdArg && *runCmdArg != "" {
 		return c.errorWithUsage(errors.New("Cannot specify an override command and disable it at the same time"))
 	}
@@ -60,8 +54,8 @@ func (c *ContainerSetCommand) Run(args []string) int {
 			c.Ui.Warn("Number of instances cannot be 0 or negative. This value won't be set.")
 		}
 
-		if *updateCmdArg == "" && *buildServiceArg == "" && *runCmdArg == "" && !*noRunCmdArg && !*noUpdateCmdArg && *limitCPUArg < 0 && *limitMemoryArg < 0 && *limitNetArg < 0 {
-			err := errors.New("Invalid values provided for instance number and update command.")
+		if *buildServiceArg == "" && *runCmdArg == "" && !*noRunCmdArg && *limitCPUArg < 0 && *limitMemoryArg < 0 && *limitNetArg < 0 {
+			err := errors.New("Invalid values provided for instance number.")
 			return c.errorWithUsage(err)
 		}
 	}
@@ -80,20 +74,6 @@ func (c *ContainerSetCommand) Run(args []string) int {
 			c.info("Configure service with %d instances", *nInstancesArg)
 		}
 
-		if *updateCmdArg != "" {
-			c.info("Configure service with update command: %s", *updateCmdArg)
-			container.PreCommand, err = shellquote.Split(*updateCmdArg)
-			if err != nil {
-				return "", err
-			}
-			if container.PreCommand == nil {
-				container.PreCommand = []string{}
-			}
-		}
-		if *noUpdateCmdArg {
-			c.info("Configure service without update command")
-			container.PreCommand = []string{}
-		}
 		if *runCmdArg != "" {
 			c.info("Configure service with run command: %s", *runCmdArg)
 			container.RunCommand, err = shellquote.Split(*runCmdArg)

--- a/command/container-show.go
+++ b/command/container-show.go
@@ -52,9 +52,6 @@ func (c *ContainerShowCommand) Run(args []string) int {
 				continue
 			}
 			st, _ := co.Status()
-			if co.NomadStatus.PreCommand.PlacementFailure {
-				st += ", pre-command error"
-			}
 			if co.NomadStatus.Service.PlacementFailure {
 				st += ", service error"
 			}
@@ -63,7 +60,6 @@ func (c *ContainerShowCommand) Run(args []string) int {
 			tbl += fmt.Sprintf("Name:\t%s\n", co.ShortName)
 			tbl += fmt.Sprintf("Status:\t%s\n", st)
 			tbl += fmt.Sprintf("Size:\t%d/%d\n", co.Running, co.Size)
-			tbl += fmt.Sprintf("Pre Command:\t%s\n", shellquote.Join(co.PreCommand...))
 			tbl += fmt.Sprintf("Run Command:\t%s\n", shellquote.Join(co.RunCommand...))
 			tbl += fmt.Sprintf("Web:\t%v\n", co.Web)
 			tbl += fmt.Sprintf("Web Port:\t%d\n", co.WebPort)
@@ -87,13 +83,6 @@ func (c *ContainerShowCommand) Run(args []string) int {
 			}
 
 			placementErrors := false
-			if co.NomadStatus.PreCommand.PlacementFailure {
-				placementErrors = true
-				msg += fmt.Sprintf("Pre Command Errors:\n")
-				for _, e := range co.NomadStatus.PreCommand.Errors("pre command") {
-					msg += fmt.Sprintf("  - %s\n", e)
-				}
-			}
 
 			if co.NomadStatus.Service.PlacementFailure {
 				placementErrors = true

--- a/command/flags.go
+++ b/command/flags.go
@@ -78,16 +78,8 @@ func containerBuildServiceFlag(f *flag.FlagSet) *string {
 	return f.String("build-service", "", "Build service to use (internal|travis)")
 }
 
-func containerNoUpdateCmdFlag(f *flag.FlagSet) *bool {
-	return f.Bool("no-update", false, "Disable update command")
-}
-
 func containerNoRunCmdFlag(f *flag.FlagSet) *bool {
 	return f.Bool("no-command", false, "Disable command override")
-}
-
-func containerUpdateCmdFlag(f *flag.FlagSet) *string {
-	return f.String("update", "", "Update command to run for each build")
 }
 
 func containerRunCmdFlag(f *flag.FlagSet) *string {

--- a/squarescale/containers.go
+++ b/squarescale/containers.go
@@ -11,7 +11,6 @@ import (
 type Container struct {
 	ID                   int                  `json:"id"`
 	ShortName            string               `json:"short_url"`
-	PreCommand           []string             `json:"pre_command"`
 	RunCommand           []string             `json:"run_command"`
 	Running              int                  `json:"running"`
 	Size                 int                  `json:"size"`
@@ -31,8 +30,7 @@ type Container struct {
 }
 
 type ContainerNomadStatus struct {
-	Service    JobNomadStatus `json:"service"`
-	PreCommand JobNomadStatus `json:"pre_command"`
+	Service JobNomadStatus `json:"service"`
 }
 
 type JobNomadStatus struct {
@@ -151,9 +149,6 @@ func (c *Client) GetContainerInfo(project, shortName string) (Container, error) 
 // ConfigContainer calls the API to update the number of instances and update command.
 func (c *Client) ConfigContainer(container Container) error {
 	cont := JSONObject{}
-	if container.PreCommand != nil {
-		cont["pre_command"] = container.PreCommand
-	}
 	if container.RunCommand != nil {
 		cont["run_command"] = container.RunCommand
 	}


### PR DESCRIPTION
Update command, also known as pre-command has been disabled. Remove
support from it in the CLI.

LLR: https://github.com/squarescale/platform/issues/846
HLR: https://github.com/squarescale/platform/issues/838



Please describe the purpose of your change.


To be filled by the author.

### General

- [x] Higher level issue: `<please link it here>`
- [x] In the scope of the current sprint

### Type of change

- [x] :bug: Bug fix
- [ ] :sparkles: New Feature
- [ ] :art: Refactoring
- [ ] :shirt: Removing lint warnings
- [ ] :memo: Documentation
- [ ] :white_check_mark: Adding tests
- [ ] :green_heart: Fixing CI
- [ ] :blue_heart: Fixing QA
- [ ] :yellow_heart: Fixing Rollbar
- [ ] :arrow_up: Upgrading dependencies
- [ ] :arrow_down: Downgrading dependencies
- [ ] :question: ...

### Scope of change

- [ ] :lipstick: Frontend
- [x] :wrench: Back-end, API
- [ ] :rocket: Deployement, configuration
- [ ] :lock: Security
- [ ] :card_index: Data migration

### How to test

- [x] Test scenario (see LLR)
- [ ] Fully covered by unit tests
- [ ] Fully covered by QA tests

### Misc

- [x] Commit messages are clear, log is readable
- [x] Branch name and commit messages contain reference to the higher issue
- [x] Code is rebased on top of master
- [x] Request is added to the task board


To be filled by the reviewers.

- [ ] No Hound violation
- [ ] Code coverage is ok
- [ ] Goal and impact of the feature are clear