### PR TITLE
[838 846] Remove references to update command in help

### DIFF
--- a/command/container-set.go
+++ b/command/container-set.go
@@ -127,16 +127,13 @@ func (c *ContainerSetCommand) Help() string {
 usage: sqsc container set [options]
 
   Set container runtime parameters for a Squarescale project.
-  '-update' options is an update command which will be run at
-  each build for the specified container, eg "rake db:migrate".
   Containers are specified using the form '${USER}/${REPOSITORY}'
 
 Example:
   sqsc container set                \
-      --project="my-rails-project"  \
-      --container="my-name/my-repo" \
-      --instances=42                \
-      --update="rake db:migrate"
+      -project="my-rails-project"  \
+      -container="my-name/my-repo" \
+      -instances=42
 
 `
 	return strings.TrimSpace(helpText + optionsFromFlags(c.flagSet))


### PR DESCRIPTION
LLR: https://github.com/squarescale/platform/issues/846
HLR: https://github.com/squarescale/platform/issues/838



Please describe the purpose of your change.


To be filled by the author.

### General

- [x] Higher level issue: `<please link it here>`
- [x] In the scope of the current sprint

### Type of change

- [x] :bug: Bug fix
- [ ] :sparkles: New Feature
- [ ] :art: Refactoring
- [ ] :shirt: Removing lint warnings
- [ ] :memo: Documentation
- [ ] :white_check_mark: Adding tests
- [ ] :green_heart: Fixing CI
- [ ] :blue_heart: Fixing QA
- [ ] :yellow_heart: Fixing Rollbar
- [ ] :arrow_up: Upgrading dependencies
- [ ] :arrow_down: Downgrading dependencies
- [ ] :question: ...

### Scope of change

- [x] :lipstick: Frontend
- [ ] :wrench: Back-end, API
- [ ] :rocket: Deployement, configuration
- [ ] :lock: Security
- [ ] :card_index: Data migration

### How to test

- [x] Test scenario: Check `sqsc constainer set -help` don't contain references
  to update command
- [ ] Fully covered by unit tests
- [ ] Fully covered by QA tests

### Misc

- [x] Commit messages are clear, log is readable
- [x] Branch name and commit messages contain reference to the higher issue
- [x] Code is rebased on top of master
- [x] Request is added to the task board


To be filled by the reviewers.

- [ ] No Hound violation
- [ ] Code coverage is ok
- [ ] Goal and impact of the feature are clear