### PR TITLE
[SQSC-17] Don't ask github a specific scope

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -40,8 +40,7 @@ func GeneratePersonalToken(login, password string, prompt OneTimePasswordPrompt)
 		var req *http.Request
 		var res *http.Response
 		params := ghAuthorizationRequestParams{
-			Scopes: []string{"user"},
-			Note:   "Squarescale CLI",
+			Note: "Squarescale CLI",
 		}
 
 		if i > 1 {


### PR DESCRIPTION
We don't need to ask any kind of scope to Github, we only need to
retrieve a valid github oauth token to be able to authentified ourselve
to squarescale-web.
As we are lowering the needed scope, the previous scope here ('user') is
higher than the scope we asked on squarescale-web's side.

Please describe the purpose of your change.

## Pre submit Checklist

To be filled by the author.

### General

- [x] Higher level issue: https://squarescale.atlassian.net/browse/SQSC-17
- [x] In the scope of the current sprint

### Type of change

- [ ] :bug: Bug fix
- [x] :sparkles: New Feature
- [ ] :art: Refactoring
- [ ] :shirt: Removing lint warnings
- [ ] :memo: Documentation
- [ ] :white_check_mark: Adding tests
- [ ] :green_heart: Fixing CI
- [ ] :blue_heart: Fixing QA
- [ ] :yellow_heart: Fixing Rollbar
- [ ] :arrow_up: Upgrading dependencies
- [ ] :arrow_down: Downgrading dependencies
- [ ] :question: ...

### Scope of change

- [ ] :lipstick: Frontend
- [ ] :wrench: Back-end, API
- [ ] :rocket: Deployement, configuration
- [x] :lock: Security
- [ ] :card_index: Data migration

### How to test

- [ ] Test scenario (please describe it)
- [ ] Fully covered by unit tests
- [ ] Fully covered by QA tests

### Misc

- [ ] Commit messages are clear, log is readable
- [ ] Branch name and commit messages contain reference to the higher issue
- [ ] Code is rebased on top of master
- [ ] Request is added to the task board

## Review Checklist

To be filled by the reviewers.

- [ ] No Hound violation
- [ ] Code coverage is ok
- [ ] Goal and impact of the feature are clear
