### PR TITLE
INFRA-523 Fix default node size when not specified

### DIFF
--- a/command/project-create.go
+++ b/command/project-create.go
@@ -56,20 +56,22 @@ func (c *ProjectCreateCommand) Run(args []string) int {
 		var definitiveName string
 		var err error
 
-		if nodeSize != "" {
-			nodeSizes, err := client.GetClusterNodeSizes()
-			if err != nil {
-				return "", err
+		if nodeSize == "" {
+			if c.Cluster.InfraType == "single-node" {
+				nodeSize = "dev"
+			} else {
+				nodeSize = "small"
 			}
-			c.Cluster.NodeSize = nodeSizes.CheckSize(nodeSize, c.Cluster.InfraType)
-			if c.Cluster.NodeSize == "" {
-				availableSizes := nodeSizes.ListSizes(c.Cluster.InfraType)
-				return "", fmt.Errorf("Cannot validate node size '%s'. Must be one of:\n* %s", nodeSize, strings.Join(availableSizes, "\n* "))
-			}
-		} else if c.Cluster.InfraType == "single-node" {
-			c.Cluster.NodeSize = "dev"
-		} else {
-			c.Cluster.NodeSize = "small"
+		}
+
+		nodeSizes, err := client.GetClusterNodeSizes()
+		if err != nil {
+			return "", err
+		}
+		c.Cluster.NodeSize = nodeSizes.CheckSize(nodeSize, c.Cluster.InfraType)
+		if c.Cluster.NodeSize == "" {
+			availableSizes := nodeSizes.ListSizes(c.Cluster.InfraType)
+			return "", fmt.Errorf("Cannot validate node size '%s'. Must be one of:\n* %s", nodeSize, strings.Join(availableSizes, "\n* "))
 		}
 
 		if c.Db.Engine != "" {


### PR DESCRIPTION
In APP-282 we introduce a new way to compute node sizes. But the default
case, when nothing is entered, was left on the side.
If the user doesn't set a node size, we first set it to the default `dev`
or `small` and then let the `nodeSizes.CheckSize` operate to normalize
it with right sizes like `small_t3`.
This way in both cases (user input or not) the computation of the node
size is the same.