### PR TITLE
Return proper error message on web service internal error

### DIFF
--- a/squarescale/image.go
+++ b/squarescale/image.go
@@ -23,14 +23,14 @@ func (c *Client) AddImage(project, name, username, password string, instances in
 
 	code, body, err := c.post("/projects/"+project+"/docker_images", &payload)
 	if err != nil {
-		return err
+		return fmt.Errorf("Cannot add docker image '%s' to project '%s' (%d %s)\n\t%s", name, project, code, http.StatusText(code), err)
 	}
 
 	switch code {
 	case http.StatusCreated:
 		return nil
 	default:
-		return readErrors(body, fmt.Sprintf("Cannot add docker image '%s' to project '%s'", name, project))
+		return readErrors(body, fmt.Sprintf("Cannot add docker image '%s' to project '%s' (%d %s)", name, project, code, http.StatusText(code)))
 	}
 }
 


### PR DESCRIPTION
Currently the following is returned when remote error 500 occurs on web service:

<img width="944" alt="Screenshot 2020-05-13 at 07 36 29" src="https://user-images.githubusercontent.com/1381878/81775159-87d07600-94ec-11ea-9e7c-2b7c2c55fc24.png">

with the fix:

<img width="942" alt="Screenshot 2020-05-13 at 07 38 08" src="https://user-images.githubusercontent.com/1381878/81775222-b5b5ba80-94ec-11ea-84bc-fe968c71b483.png">
