### PR TITLE
db: fixes db version

### DIFF
--- a/command/flags.go
+++ b/command/flags.go
@@ -392,7 +392,7 @@ func dbSizeFlag(f *flag.FlagSet) *string {
 }
 
 func dbVersionFlag(f *flag.FlagSet) *string {
-	return f.String("version", "", "Database version")
+	return f.String("db-version", "", "Database version")
 }
 
 func dbBackupFlag(f *flag.FlagSet) *bool {


### PR DESCRIPTION
it clashes with the CLI version flag.

the patch renames the flag 'version' to 'db-version',
which is coherant with command 'project create [..] -db-version xx'
